### PR TITLE
Add -latomic to linker flags for venc sample

### DIFF
--- a/middleware/v2/sample/venc/Makefile
+++ b/middleware/v2/sample/venc/Makefile
@@ -51,7 +51,7 @@ LIBS += -lcli
 endif
 
 EXTRA_CFLAGS = $(INCS) $(DEFS)
-EXTRA_LDFLAGS = $(LIBS) -lini -lpthread
+EXTRA_LDFLAGS = $(LIBS) -latomic -lini -lpthread
 
 EXTRA_LDFLAGS_WITH_ASAN = -Wl,-Bdynamic $(LIBS) -lini -lpthread
 


### PR DESCRIPTION
Building on debian testing fails with the following:

 | make[1]: Entering directory '/oupton/milkv/duo/duo-buildroot-sdk/middleware/v2/sample/venc'
 | [riscv64-unknown-linux-musl-gcc] sample_venc.o
 | [riscv64-unknown-linux-musl-gcc] sample_venc_lib.o
 | [riscv64-unknown-linux-musl-gcc] sample_venc_testcase.o
 | [riscv64-unknown-linux-musl-gcc] sample_vdec_lib.o
 | [riscv64-unknown-linux-musl-gcc] sample_vdec_testcase.o
 | /oupton/milkv/duo/duo-buildroot-sdk/host-tools/gcc/riscv64-linux-musl-x86_64/bin/../lib/gcc/riscv64-unknown-linux-musl/10.2.0/../../../../riscv64-unknown-linux-musl/bin/ld: /oupton/milkv/duo/duo-buildroot-sdk/middleware/v2/lib/libsys.a(cvi_vb.o): in function `CVI_VB_Init':
 | /root/.jenkins/workspace/v4.1.0_release_build/middleware/v2/modules/sys/src/cvi_vb.c:201: undefined reference to `__atomic_compare_exchange_1'
 | /oupton/milkv/duo/duo-buildroot-sdk/host-tools/gcc/riscv64-linux-musl-x86_64/bin/../lib/gcc/riscv64-unknown-linux-musl/10.2.0/../../../../riscv64-unknown-linux-musl/bin/ld: /oupton/milkv/duo/duo-buildroot-sdk/middleware/v2/lib/libsys.a(cvi_vb.o): in function `CVI_VB_Exit':
 | /root/.jenkins/workspace/v4.1.0_release_build/middleware/v2/modules/sys/src/cvi_vb.c:225: undefined reference to `__atomic_compare_exchange_1'
 | collect2: error: ld returned 1 exit status
 | make[1]: *** [Makefile:78: sample_venc] Error 1
 | make[1]: Leaving directory '/oupton/milkv/duo/duo-buildroot-sdk/middleware/v2/sample/venc'
 | make: *** [Makefile:9: all] Error 1
 | Error: Build board milkv-duo failed

Fix it by ensuring -latomic is passed to the linker.