### PR TITLE
fix(duo spinand):adjust the partition of duo spinand configuration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -185,7 +185,6 @@ function milkv_pack_nor_nand()
 		cp ${OUTPUT_DIR}/*.spinand out/$img_out_patch 	
 	fi
 	
-	touch ${OUTPUT_DIR}/how_to_download.txt
 	echo "Copy all to a blank tf card, power on and automatically download firmware to NOR or NAND in U-boot." >> out/$img_out_patch/how_to_download.txt
     print_info "Create spinor/nand img successful: ${img_out_patch}"
   else

--- a/build/Makefile
+++ b/build/Makefile
@@ -591,8 +591,8 @@ endif
 
 	# create partition mounting points and move sytems to read-write partitions
 ifeq ($(STORAGE_TYPE), spinand)
-	${Q}mkdir -p $(BR_OVERLAY_DIR)/mnt/cfg
-	${Q}mkdir -p $(BR_OVERLAY_DIR)/mnt/data
+	# ${Q}mkdir -p $(BR_OVERLAY_DIR)/mnt/cfg
+	# ${Q}mkdir -p $(BR_OVERLAY_DIR)/mnt/data
 	${Q}mkdir -p $(OUTPUT_DIR)/system
 	${Q}cp -arf $(BR_OVERLAY_DIR)/mnt/system/* $(OUTPUT_DIR)/system
 endif

--- a/build/boards/cv180x/cv1800b_milkv_duo_spinand/partition/partition_spinand.xml
+++ b/build/boards/cv180x/cv1800b_milkv_duo_spinand/partition/partition_spinand.xml
@@ -4,7 +4,5 @@
     <partition label="ENV" size_in_kb="128" file="" />
     <partition label="ENV_BAK" size_in_kb="128" file="" />
     <partition label="ROOTFS" size_in_kb="40960" file="rootfs.spinand" />
-    <partition label="SYSTEM" size_in_kb="71680" file="system.spinand" mountpoint="/mnt/system" type="ubifs" />
-    <partition label="CFG" size_in_kb="4096" file="cfg.spinand" mountpoint="/mnt/cfg" type="ubifs" />
-    <partition label="DATA" file="" mountpoint="/mnt/data" type="ubifs" />
+    <partition label="SYSTEM" size_in_kb="81152" file="system.spinand" mountpoint="/mnt/system" type="ubifs" />
 </physical_partition>

--- a/device/milkv-duo-spinand/genimage.cfg
+++ b/device/milkv-duo-spinand/genimage.cfg
@@ -34,10 +34,6 @@ image milkv-duospinand.img {
 
 	partition system {
 		image = "rawimages/system.spinand"
-		size = 71680k
+		size = 81152k
 
-	partition cfg {
-		image = "rawimages/cfg.spinand"
-		size = 4096k
-	}
 }


### PR DESCRIPTION
@carbonfix 
1.调整duo spinand 的xml分区，去掉了/mnt/cfg、/mnt/data，空间全部给/mnt/system.
2.修正了build.sh打包nand的空文件创建问题.