### PR TITLE
Remoteproc fix

### DIFF
--- a/linux_5.10/drivers/remoteproc/cvitek_remoteproc.c
+++ b/linux_5.10/drivers/remoteproc/cvitek_remoteproc.c
@@ -148,7 +148,10 @@ static int cvitek_rproc_parse_fw(struct rproc *rproc, const struct firmware *fw)
 		index++;
 	}
 
-	return rproc_elf_load_rsc_table(rproc, fw);
+	if (rproc_elf_load_rsc_table(rproc, fw))
+		dev_warn(&rproc->dev, "no resource table found for this firmware\n");
+
+	return 0;
 }
 
 static const struct rproc_ops cvitek_rproc_ops = {

--- a/linux_5.10/drivers/remoteproc/cvitek_remoteproc.c
+++ b/linux_5.10/drivers/remoteproc/cvitek_remoteproc.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <linux/clk.h>
+#include <linux/delay.h>
 #include <linux/dma-mapping.h>
 #include <linux/err.h>
 #include <linux/interrupt.h>
@@ -58,6 +59,8 @@ static int cvitek_rproc_start(struct rproc *rproc)
 	void __iomem *clk_reset = ioremap(SEC_CLK_ADDR, 4);
 
 	clrbits_32(clk_reset, 1 << 6);
+
+	udelay(10);
 
 	setbits_32(clk_reset, 1 << 6);
 


### PR DESCRIPTION
This patch enables dynamic loading of different firmware on the second core. 