### PR TITLE
Add FENCE.TSO Emulation to opensbi

### DIFF
--- a/opensbi/include/sbi/riscv_encoding.h
+++ b/opensbi/include/sbi/riscv_encoding.h
@@ -625,6 +625,9 @@
 #define INSN_MASK_WFI			0xffffff00
 #define INSN_MATCH_WFI			0x10500000
 
+#define INSN_MASK_FENCE_TSO		0xffffffff
+#define INSN_MATCH_FENCE_TSO		0x8330000f
+
 #define INSN_16BIT_MASK			0x3
 #define INSN_32BIT_MASK			0x1c
 

--- a/opensbi/lib/sbi/sbi_illegal_insn.c
+++ b/opensbi/lib/sbi/sbi_illegal_insn.c
@@ -8,6 +8,7 @@
  */
 
 #include <sbi/riscv_asm.h>
+#include <sbi/riscv_barrier.h>
 #include <sbi/riscv_encoding.h>
 #include <sbi/sbi_bitops.h>
 #include <sbi/sbi_emulate_csr.h>
@@ -29,6 +30,17 @@ static int truly_illegal_insn(ulong insn, struct sbi_trap_regs *regs)
 	trap.tinst = 0;
 
 	return sbi_trap_redirect(regs, &trap);
+}
+
+static int misc_mem_opcode_insn(ulong insn, struct sbi_trap_regs *regs)
+{
+	/* Errata workaround: emulate `fence.tso` as `fence rw, rw`. */
+	if ((insn & INSN_MASK_FENCE_TSO) == INSN_MATCH_FENCE_TSO) {
+		smp_mb();
+		return 0;
+	}
+
+	return truly_illegal_insn(insn, regs);
 }
 
 static int system_opcode_insn(ulong insn, struct sbi_trap_regs *regs)
@@ -83,7 +95,7 @@ static illegal_insn_func illegal_insn_table[32] = {
 	truly_illegal_insn, /* 0 */
 	truly_illegal_insn, /* 1 */
 	truly_illegal_insn, /* 2 */
-	truly_illegal_insn, /* 3 */
+	misc_mem_opcode_insn, /* 3 */
 	truly_illegal_insn, /* 4 */
 	truly_illegal_insn, /* 5 */
 	truly_illegal_insn, /* 6 */

--- a/opensbi/lib/sbi/sbi_illegal_insn.c
+++ b/opensbi/lib/sbi/sbi_illegal_insn.c
@@ -37,6 +37,7 @@ static int misc_mem_opcode_insn(ulong insn, struct sbi_trap_regs *regs)
 	/* Errata workaround: emulate `fence.tso` as `fence rw, rw`. */
 	if ((insn & INSN_MASK_FENCE_TSO) == INSN_MATCH_FENCE_TSO) {
 		smp_mb();
+		regs->mepc += 4;
 		return 0;
 	}
 


### PR DESCRIPTION
This is not strictly necessary for the duo-buildroot, but as some people are using this to create a fip.bin for use with other distributions (such as Ubuntu/arch etc) I'm opening this PR.

This back-ports the FENCE.TSO emulation in mainline opensbi. FENCE.TSO instruction is emitted by newer compilers and unfortunately the C906 CPU used in the CV200x is missing this instruction.

Without this fix, some binaries compiled with newer versions of GCC/Clang etc will crash with a illegal instruction (as seen here for example: https://community.milkv.io/t/alpine-linux-on-the-duo/700/17)

This should have no impact upon the duo-buildroot as the gcc version used to compile it does not emit FENCE.TSO. 