### PR TITLE
修改dts启用milkv duo/milkv duo 256m的内部dac

### DIFF
--- a/build/boards/default/dts/cv180x/cv180x_base.dtsi
+++ b/build/boards/default/dts/cv180x/cv180x_base.dtsi
@@ -617,6 +617,7 @@
 		reg = <0x0 0x0300A000 0x0 0x100>;
 		clocks = <&i2s_mclk 0>;
 		clock-names = "i2sclk";
+		clk_source = <0x04130000>; /* MCLK source is I2S3 */
 	};
 
 	pdm: pdm@0x041D0C00 {

--- a/build/boards/default/dts/cv181x/cv181x_base.dtsi
+++ b/build/boards/default/dts/cv181x/cv181x_base.dtsi
@@ -626,6 +626,7 @@
 		reg = <0x0 0x0300A000 0x0 0x100>;
 		clocks = <&i2s_mclk 0>;
 		clock-names = "i2sclk";
+		clk_source = <0x04130000>; /* MCLK source is I2S3 */
 	};
 
 	pdm: pdm@0x041D0C00 {


### PR DESCRIPTION
修改dts启用milkv duo/milkv duo 256m的内部dac
已经过板上测试，可以正常播放wav文件
似乎aplay能识别，但是播放时会产生段错误，自己编译的TinyALSA能够正常识别并播放音频文件