### PR TITLE
Add -latomic to linker flags for scene_auto sample

### DIFF
--- a/middleware/v2/sample/scene_auto/Makefile
+++ b/middleware/v2/sample/scene_auto/Makefile
@@ -34,7 +34,7 @@ LIBS += -lnanomsg
 endif
 
 EXTRA_CFLAGS = $(INCS) $(DEFS)
-EXTRA_LDFLAGS = $(LIBS) -lpthread -lm -lini
+EXTRA_LDFLAGS = $(LIBS) -lpthread -lm -lini -latomic
 
 .PHONY : clean all
 all: $(TARGET)


### PR DESCRIPTION
I encountered a bug similar to #26.

```
make[1]: Entering directory '/home/rein/duo-buildroot-sdk/middleware/v2/sample/scene_auto'
[riscv64-unknown-linux-musl-gcc] cvi_scene.o
[riscv64-unknown-linux-musl-gcc] cvi_scene_setparam.o
[riscv64-unknown-linux-musl-gcc] cvi_scene_decode.o
[riscv64-unknown-linux-musl-gcc] cvi_scene_loadparam.o
[riscv64-unknown-linux-musl-gcc] sample_scene.o
[riscv64-unknown-linux-musl-gcc] sample_scene_main.o
[riscv64-unknown-linux-musl-gcc] dictionary.o
[riscv64-unknown-linux-musl-gcc] iniparser.o
/home/rein/duo-buildroot-sdk/host-tools/gcc/riscv64-linux-musl-x86_64/bin/../lib/gcc/riscv64-unknown-linux-musl/10.2.0/../../../../riscv64-unknown-linux-musl/bin/ld: /home/rein/duo-buildroot-sdk/middleware/v2/lib/libsys.a(cvi_vb.o): in function `CVI_VB_Init':
/root/.jenkins/workspace/v4.1.0_release_build/middleware/v2/modules/sys/src/cvi_vb.c:201: undefined reference to `__atomic_compare_exchange_1'
/home/rein/duo-buildroot-sdk/host-tools/gcc/riscv64-linux-musl-x86_64/bin/../lib/gcc/riscv64-unknown-linux-musl/10.2.0/../../../../riscv64-unknown-linux-musl/bin/ld: /home/rein/duo-buildroot-sdk/middleware/v2/lib/libsys.a(cvi_vb.o): in function `CVI_VB_Exit':
/root/.jenkins/workspace/v4.1.0_release_build/middleware/v2/modules/sys/src/cvi_vb.c:225: undefined reference to `__atomic_compare_exchange_1'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:51: sample_scene_auto] Error 1
make[1]: Leaving directory '/home/rein/duo-buildroot-sdk/middleware/v2/sample/scene_auto'
```

I am on ArchLinux.