### PR TITLE
Enable the config file for aic8800

### DIFF
--- a/linux_5.10/drivers/net/wireless/aicsemi/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/linux_5.10/drivers/net/wireless/aicsemi/aic8800/aic8800_fdrv/rwnx_main.c
@@ -6781,15 +6781,13 @@ int rwnx_cfg80211_init(struct rwnx_plat *rwnx_plat, void **platform_data)
 	tcp_ack_init(rwnx_hw);
 #endif
 
-#if 0
+	/* Set a default mac address with the last 2 bytes randomized */
+	memcpy(init_conf.mac_addr, dflt_mac, ETH_ALEN);
+
 	ret = rwnx_parse_configfile(rwnx_hw, RWNX_CONFIG_FW_NAME, &init_conf);
 	if (ret) {
-		wiphy_err(wiphy, "rwnx_parse_configfile failed\n");
-		goto err_config;
+		// do nothing
 	}
-#else
-	memcpy(init_conf.mac_addr, dflt_mac, ETH_ALEN);
-#endif
 
 	rwnx_hw->vif_started = 0;
 	rwnx_hw->monitor_vif = RWNX_INVALID_VIF;
@@ -6976,14 +6974,13 @@ int rwnx_cfg80211_init(struct rwnx_plat *rwnx_plat, void **platform_data)
 
 	if (mac_addr_efuse[0] | mac_addr_efuse[1] | mac_addr_efuse[2] | mac_addr_efuse[3]) {
 		memcpy(init_conf.mac_addr, mac_addr_efuse, ETH_ALEN);
-	}else{
-        memcpy(init_conf.mac_addr, dflt_mac, ETH_ALEN);
-    }
+	}
 
 
-	AICWFDBG(LOGINFO, "get macaddr: %02x:%02x:%02x:%02x:%02x:%02x\r\n",
+	AICWFDBG(LOGINFO, "efuse macaddr: %02x:%02x:%02x:%02x:%02x:%02x\r\n",
 			mac_addr_efuse[0], mac_addr_efuse[1], mac_addr_efuse[2],
 			mac_addr_efuse[3], mac_addr_efuse[4], mac_addr_efuse[5]);
+
 	memcpy(wiphy->perm_addr, init_conf.mac_addr, ETH_ALEN);
 
 	/* Reset FW */


### PR DESCRIPTION
Currently there's no way to configure the mac address used by aic8800 even though various methods are coded in.

The current default behavior uses hardcoded default mac address of which the last two bytes are randomized _on each boot_.

This causes some networking issues, for instance a new DHCP lease is requested on each startup and it's near impossible to assign a static ip from a dhcp server.

This issue has been [discussed on the forums](https://community.milkv.io/t/mac-address-locking-does-not-work-for-wifi/1648/1).

One could use a script to modify the wlan0 device and change the address but this isn't optimal.

Within the `aic8800` sourcecode is a previously unused configuration parser. I slightly modified en re-enabled it.
It needed modification because the first implementation relied on `request_firmware`, however there already existsa wrapper called rwnx_request_firmware_common in `rwnx_platform.c` that can load a firmware from the disk or via `request_firmware`.

I also had to slightly alter the login around setting the mac address.

However the behavior should remain exactly the same without the presence of the config file.

I also tried applying [this efuse patch](https://lore.kernel.org/linux-riscv/20231119131332.999-1-jszhang@kernel.org/) but the driver was unable to request the permanent hardware mac address from the efuses. However if in the future this is possible, then the efuse mac address will overwrite the one in the configuration because the check for this is done later.

To make use of this new change one can create a file `/mnt/system/firmware/aic8800/rwxn_settings.ini` .
Within it, the address can be configured like so:
```
MAC_ADDR=aa:bb:cc:dd:ee:ff
```

It could also be interesting to look at [how the RockPi-S handles the wlan mac address](https://github.com/radxa-pkg/aic8800/blob/a9b8d745af8e6bdeae2349d32791ec0aea32bdc8/src/SDIO/patch/for_Rockchip/3128/Android4_4/mod/kernel/net/rfkill/rfkill-wlan.c#L545-L631).

Another preferred method could be to save a random mac address to a file in `/var/run` on the first boot and continue using it. This will ensure that each Duo has a different but persistent mac address without configuration. Please let me know what you think of this.
