### PR TITLE
fix build.sh typo

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -83,7 +83,7 @@ cd duo-buildroot-sdk/
 # ./build.sh
 Usage:
 ./build.sh              - Show this menu
-./build.sh lunch        - Select a board to build
+./build.sh launch       - Select a board to build
 ./build.sh [board]      - Build [board] directly, supported boards asfollows:
 milkv-duo
 milkv-duo256m
@@ -92,9 +92,9 @@ milkv-duo256m
 
 プロンプトにあるように、ターゲット向けにコンパイルするには2つ方法があります。
 
-1つ目の方法は、`build.sh lunch`でインタラクティブメニューを立ち上げて、ターゲットのバージョンの番号を選択し、Enterを押すだけです。
+1つ目の方法は、`build.sh launch`でインタラクティブメニューを立ち上げて、ターゲットのバージョンの番号を選択し、Enterを押すだけです。
 ```bash
-# ./build.sh lunch
+# ./build.sh launch
 Select a target to build:
 1. milkv-duo
 2. milkv-duo256m
@@ -194,7 +194,7 @@ CONTAINER ID   IMAGE                        COMMAND       CREATED       STATUS  
 ```bash
 docker exec -it duodocker /bin/bash -c "cd /home/work && cat /etc/issue && ./build.sh [board]"
 ```
-`./build.sh [board]`のコマンドの終端についてはUbuntu 20.04での自動コンパイルスクリプトでの使い方と同じです。`./build.sh`で使い方が表示され、`./build.sh lunch`で選択画面を表示できます。`./build.sh [board]`で直接ターゲット向けにコンパイルできます。`[board]`の部分は以下に置き換えられます。ターゲットに合わせてください。
+`./build.sh [board]`のコマンドの終端についてはUbuntu 20.04での自動コンパイルスクリプトでの使い方と同じです。`./build.sh`で使い方が表示され、`./build.sh launch`で選択画面を表示できます。`./build.sh [board]`で直接ターゲット向けにコンパイルできます。`[board]`の部分は以下に置き換えられます。ターゲットに合わせてください。
 
 ```
 milkv-duo

--- a/README-zh.md
+++ b/README-zh.md
@@ -66,7 +66,7 @@ cd duo-buildroot-sdk/
 ```bash
 # ./build.sh
 ./build.sh              - Show this menu
-./build.sh lunch        - Select a board to build
+./build.sh launch       - Select a board to build
 ./build.sh [board]      - Build [board] directly, supported boards as follows:
 milkv-duo
 milkv-duo-spinand
@@ -82,9 +82,9 @@ milkv-duos-sd
 
 如提示中所示，有两种方法来编译目录版本。
 
-第一种方法是执行 `./build.sh lunch` 调出交互菜单，选择要编译的版本序号，回车：
+第一种方法是执行 `./build.sh launch` 调出交互菜单，选择要编译的版本序号，回车：
 ```bash
-# ./build.sh lunch
+# ./build.sh launch
 Select a target to build:
 1. milkv-duo
 2. milkv-duo-spinand
@@ -199,7 +199,7 @@ CONTAINER ID   IMAGE                        COMMAND       CREATED       STATUS  
 docker exec -it duodocker /bin/bash -c "cd /home/work && cat /etc/issue && ./build.sh [board]"
 ```
 
-注意命令最后的 `./build.sh [board]` 和前面在 Ubuntu 22.04 中一键编译说明中的用法是一样的，直接 `./build.sh` 可以查看命令的使用方法，用 `./build.sh lunch` 可以调出交互选择菜单，用 `./build.sh [board]` 可以直接编译目标版本，`[board]` 可以替换为:
+注意命令最后的 `./build.sh [board]` 和前面在 Ubuntu 22.04 中一键编译说明中的用法是一样的，直接 `./build.sh` 可以查看命令的使用方法，用 `./build.sh launch` 可以调出交互选择菜单，用 `./build.sh [board]` 可以直接编译目标版本，`[board]` 可以替换为:
 ```
 milkv-duo
 milkv-duo-spinand

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You will see tips on how to use the compiled script:
 # ./build.sh
 Usage:
 ./build.sh              - Show this menu
-./build.sh lunch        - Select a board to build
+./build.sh launch       - Select a board to build
 ./build.sh [board]      - Build [board] directly, supported boards asfollows:
 milkv-duo
 milkv-duo256m
@@ -78,9 +78,9 @@ Listed at the bottom is the list of currently supported target versions.
 
 As shown in the prompt, there are two ways to compile the target version.
 
-The first method is to execute `./build.sh lunch` to bring up the interactive menu, select the version number to be compiled, and press Enter:
+The first method is to execute `./build.sh launch` to bring up the interactive menu, select the version number to be compiled, and press Enter:
 ```bash
-# ./build.sh lunch
+# ./build.sh launch
 Select a target to build:
 1. milkv-duo
 2. milkv-duo256m
@@ -180,7 +180,7 @@ CONTAINER ID   IMAGE                        COMMAND       CREATED       STATUS  
 docker exec -it duodocker /bin/bash -c "cd /home/work && cat /etc/issue && ./build.sh [board]"
 ```
 
-Note that the `./build.sh [board]` at the end of the command is the same as the previous usage in the one-click compilation instructions in Ubuntu 22.04. Use `./build.sh` can see how to use the command, use `./ build.sh lunch` can bring up the interactive selection menu, use `./build.sh [board]` to directly compile the target version, `[board]` can be replaced with:
+Note that the `./build.sh [board]` at the end of the command is the same as the previous usage in the one-click compilation instructions in Ubuntu 22.04. Use `./build.sh` can see how to use the command, use `./ build.sh launch` can bring up the interactive selection menu, use `./build.sh [board]` to directly compile the target version, `[board]` can be replaced with:
 ```
 milkv-duo
 milkv-duo256m

--- a/build.sh
+++ b/build.sh
@@ -220,7 +220,7 @@ function build_usage()
 {
   echo "Usage:"
   echo "${BASH_SOURCE[0]}              - Show this menu"
-  echo "${BASH_SOURCE[0]} lunch        - Select a board to build"
+  echo "${BASH_SOURCE[0]} launch       - Select a board to build"
   echo "${BASH_SOURCE[0]} [board]      - Build [board] directly, supported boards as follows:"
 
   for board in "${MILKV_BOARD_ARRAY[@]}"; do
@@ -229,7 +229,7 @@ function build_usage()
 }
 
 if [ $# -ge 1 ]; then
-  if [ "$1" = "lunch" ]; then
+  if [ "$1" = "launch" ]; then
     choose_board || exit 0
   else
     if [[ ${MILKV_BOARD_ARRAY[@]} =~ (^|[[:space:]])"${1}"($|[[:space:]]) ]]; then


### PR DESCRIPTION
This fixes a build.sh typo. 
Replaces lunch with launch in the script and all the README files