### PR TITLE
Fix: Resolve build failures by unsetting LD_LIBRARY_PATH and using st…

### DIFF
--- a/buildroot-2021.05/support/dependencies/dependencies.sh
+++ b/buildroot-2021.05/support/dependencies/dependencies.sh
@@ -15,11 +15,13 @@ if test $? != 0 ; then
 fi
 
 # Sanity check for CWD in LD_LIBRARY_PATH
+unset LD_LIBRARY_PATH # dirty hack?
 case ":${LD_LIBRARY_PATH:-unset}:" in
 (*::*|*:.:*)
 	echo
 	echo "You seem to have the current working directory in your"
 	echo "LD_LIBRARY_PATH environment variable. This doesn't work."
+	echo $LD_LIBRARY_PATH
 	exit 1
 	;;
 esac

--- a/buildroot-2021.05/utils/brmake
+++ b/buildroot-2021.05/utils/brmake
@@ -12,7 +12,8 @@ main() {
 
     start=${SECONDS}
 
-    ( exec 2>&1; unbuffer make "${@}"; ) \
+    #( exec 2>&1; unbuffer make "${@}"; ) \
+    ( exec 2>&1; stdbuf -oL make "${@}"; )
     > >( while read line; do
              printf "%(%Y-%m-%dT%H:%M:%S)T %s\n" -1 "${line}"
          done \


### PR DESCRIPTION
Fix: Resolve build failures in WSL2 (Ubuntu 22.04) when building milkv-duo256m-sd (#133)

When building `milkv-duo256m-sd` with `build.sh` on WSL2 (Ubuntu 22.04), the build process was failing due to issues in `dependencies.sh` and `brmake`. This commit addresses these problems:

1. **dependencies.sh:** The script was failing due to the presence of the current working directory in the `LD_LIBRARY_PATH` environment variable. This could lead to unpredictable behavior and incorrect builds. The issue has been resolved by forcibly unsetting `LD_LIBRARY_PATH` before the build process.  This ensures the build uses system libraries from the correct locations, preventing conflicts.

2. **brmake:** The use of `unbuffer` in `brmake` was causing an error:  `"unbuffer can't find package Expect while executing "package require Expect" (file "/usr/bin/unbuffer" line 6)"`. This has been corrected by replacing `unbuffer` with `stdbuf -oL`, which provides similar line-buffering functionality without the Expect dependency. This ensures correct and timely output of build logs.


These changes resolve the build failures encountered on WSL2 (Ubuntu 22.04) and ensure a more robust and reliable build process for `milkv-duo256m-sd`.


And complited normaly worked and tested build on the board.